### PR TITLE
Add SecretName in TLS + adapt github actions

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -12,6 +12,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tests-results
+          path: |
+            coverprofile.out
+            gotest.json
       - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -25,6 +31,13 @@ jobs:
       - name: Launch Test
         run: |
           go vet ./... && go test -coverprofile=coverprofile.out -json -v ./... > gotest.json
+  sonar:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: tests-results
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -12,12 +12,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/upload-artifact@v4
-        with:
-          name: tests-results
-          path: |
-            coverprofile.out
-            gotest.json
       - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -31,6 +25,12 @@ jobs:
       - name: Launch Test
         run: |
           go vet ./... && go test -coverprofile=coverprofile.out -json -v ./... > gotest.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tests-results
+          path: |
+            coverprofile.out
+            gotest.json
   sonar:
     runs-on: ubuntu-latest
     needs: tests

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -9,7 +9,7 @@ on:
       - master
       - develop
 jobs:
-  test:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: tests-results

--- a/generator/ingress_test.go
+++ b/generator/ingress_test.go
@@ -31,7 +31,11 @@ services:
 	os.Chdir(tmpDir)
 	defer os.Chdir(currentDir)
 
-	output := internalCompileTest(t, "-s", "templates/web/ingress.yaml", "--set", "web.ingress.enabled=true")
+	output := internalCompileTest(
+		t,
+		"-s", "templates/web/ingress.yaml",
+		"--set", "web.ingress.enabled=true",
+	)
 	ingress := v1.Ingress{}
 	if err := yaml.Unmarshal([]byte(output), &ingress); err != nil {
 		t.Errorf(unmarshalError, err)
@@ -41,5 +45,84 @@ services:
 	}
 	if ingress.Spec.Rules[0].Host != "my.test.tld" {
 		t.Errorf("Expected host to be my.test.tld, got %s", ingress.Spec.Rules[0].Host)
+	}
+}
+
+func TestTLS(t *testing.T) {
+	composeFile := `
+services:
+    web:
+        image: nginx:1.29
+        ports:
+        - 80:80
+        - 443:443
+        labels:
+            %s/ingress: |-
+                hostname: my.test.tld
+                port: 80
+`
+	composeFile = fmt.Sprintf(composeFile, labels.KatenaryLabelPrefix)
+	tmpDir := setup(composeFile)
+	defer teardown(tmpDir)
+
+	currentDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(currentDir)
+
+	output := internalCompileTest(
+		t,
+		"-s", "templates/web/ingress.yaml",
+		"--set", "web.ingress.enabled=true",
+	)
+	ingress := v1.Ingress{}
+	if err := yaml.Unmarshal([]byte(output), &ingress); err != nil {
+		t.Errorf(unmarshalError, err)
+	}
+	// find the tls section
+	tls := ingress.Spec.TLS
+	if len(tls) != 1 {
+		t.Errorf("Expected 1 tls section, got %d", len(tls))
+	}
+}
+
+func TestTLSName(t *testing.T) {
+	composeFile := `
+services:
+    web:
+        image: nginx:1.29
+        ports:
+        - 80:80
+        - 443:443
+        labels:
+            %s/ingress: |-
+                hostname: my.test.tld
+                port: 80
+`
+	composeFile = fmt.Sprintf(composeFile, labels.KatenaryLabelPrefix)
+	tmpDir := setup(composeFile)
+	defer teardown(tmpDir)
+
+	currentDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(currentDir)
+
+	output := internalCompileTest(
+		t,
+		"-s",
+		"templates/web/ingress.yaml",
+		"--set", "web.ingress.enabled=true",
+		"--set", "web.ingress.tls.secretName=mysecret",
+	)
+	ingress := v1.Ingress{}
+	if err := yaml.Unmarshal([]byte(output), &ingress); err != nil {
+		t.Errorf(unmarshalError, err)
+	}
+	// find the tls section
+	tls := ingress.Spec.TLS
+	if len(tls) != 1 {
+		t.Errorf("Expected 1 tls section, got %d", len(tls))
+	}
+	if tls[0].SecretName != "mysecret" {
+		t.Errorf("Expected secretName to be mysecret, got %s", tls[0].SecretName)
 	}
 }

--- a/generator/values.go
+++ b/generator/values.go
@@ -21,7 +21,8 @@ type PersistenceValue struct {
 }
 
 type TLS struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled    bool   `yaml:"enabled"`
+	SecretName string `yaml:"secretName"`
 }
 
 // IngressValue is a ingress configuration that will be saved in values.yaml.
@@ -92,6 +93,10 @@ func (v *Value) AddIngress(host, path string) {
 		Host:    host,
 		Path:    path,
 		Class:   "-",
+		TLS: TLS{
+			Enabled:    true,
+			SecretName: "",
+		},
 	}
 }
 


### PR DESCRIPTION
- The TLS `secretName` wasn't editable, it is now
- It uses variables creation inside the Ingress template to simplify
- We now use 2 jobs in GH Actions to have SonarQube in a separated job