### PR TITLE
fix(configmap): File from the root of project ends by a dash

### DIFF
--- a/generator/configMap_test.go
+++ b/generator/configMap_test.go
@@ -2,8 +2,10 @@ package generator
 
 import (
 	"fmt"
+	"io"
 	"katenary/generator/labels"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -88,5 +90,43 @@ func TestAppendBadDir(t *testing.T) {
 	err := cm.AppendDir("foo")
 	if err == nil {
 		t.Errorf("Expected error, got nil")
+	}
+}
+
+func TestRootConfigmapfile(t *testing.T) {
+	composeFile := `
+services:
+  web:
+    image: nginx
+    volumes:
+      - ./foo.txt:/etc/foo.txt
+    labels:
+      %[1]s/configmap-files: |-
+        - ./foo.txt
+`
+	composeFile = fmt.Sprintf(composeFile, labels.KatenaryLabelPrefix)
+	tmpDir := setup(composeFile)
+	defer teardown(tmpDir)
+
+	currentDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(currentDir)
+	fooTxt := "foo content"
+	fooFp, _ := os.Create("foo.txt")
+	io.WriteString(fooFp, fooTxt)
+	fooFp.Close()
+
+	output := internalCompileTest(t, "-s", "templates/web/statics/configmap.yaml")
+	configMap := v1.ConfigMap{}
+	if err := yaml.Unmarshal([]byte(output), &configMap); err != nil {
+		t.Errorf(unmarshalError, err)
+	}
+	if configMap.Data == nil {
+		t.Error("Expected configmap data to not be nil")
+	}
+	// if the configmap.Name ends by anything that is not alphanumeric, there is a problem
+	valid := regexp.MustCompile(`.*[a-zA-Z0-9]+$`)
+	if !valid.MatchString(configMap.Name) {
+		t.Errorf("ConfigMap name %s is not valid", configMap.Name)
 	}
 }

--- a/generator/deployment.go
+++ b/generator/deployment.go
@@ -635,12 +635,16 @@ func (d *Deployment) appendFileToConfigMap(service types.ServiceConfig, appName 
 	// in generate.go
 	dirname := filepath.Dir(volume.Source)
 	pathname := utils.PathToName(dirname)
+	pathname = strings.TrimSpace(pathname)
+	if len(pathname) != 0 {
+		pathname += "-" + pathname
+	}
 	var cm *ConfigMap
 	if v, ok := d.configMaps[pathname]; !ok {
 		cm = NewConfigMap(*d.service, appName, true)
 		cm.usage = FileMapUsageFiles
 		cm.path = dirname
-		cm.Name = utils.TplName(service.Name, appName) + "-" + pathname
+		cm.Name = utils.TplName(service.Name, appName) + pathname
 		d.configMaps[pathname] = &ConfigMapMount{
 			configMap: cm,
 			mountPath: []mountPathConfig{{


### PR DESCRIPTION
fixes #150

If we mount a file from the root of project, the names ends by a dash. That makes helm failing to install the package.