### PR TITLE
feat(oci): Use Buildah

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -1,9 +1,9 @@
 name: Build OCI image
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - "**"
 
 env:
   REGISTRY: ghcr.io
@@ -12,26 +12,28 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      - name: Build image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
         with:
+          image: ghcr.io/katenary/katenary
+          tags: latest ${{ github.ref_name }}
+          containerfiles: |
+            ./oci/katenary/Containerfile
+          build-args: |
+            VERSION=${{ github.ref_name }}
+      - name: Push image
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./oci/katenary/Containerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{github.ref_name}}

--- a/oci/katenary/Containerfile
+++ b/oci/katenary/Containerfile
@@ -1,15 +1,26 @@
 ARG GOVERSION=1.24
 
 FROM docker.io/golang:${GOVERSION} AS builder
-ARG VERSION=master
+ARG VERSION
+RUN \
+  if [ "${VERSION}" = "" ]; then\ 
+  echo "You must set VERSION build argument"; \
+  exit 1; \
+  fi
+COPY go.mod go.sum /go/src/github.com/katenary/katenary/
+COPY cmd /go/src/github.com/katenary/katenary/cmd
+COPY internal /go/src/github.com/katenary/katenary/internal
+WORKDIR /go/src/github.com/katenary/katenary
+ENV CGO_ENABLED=0
 RUN set -xe; \
-  CGO_ENABLED=0 go install -v github.com/katenary/katenary/cmd/katenary@$VERSION;
+  go build -ldflags="-X 'github.com/katenary/katenary/internal/generator.Version=v${VERSION}'" -trimpath -o katenary ./cmd/katenary
+
 
 FROM scratch
 LABEL org.opencontainers.image.source=https://github.com/katenary/katenary
 LABEL org.opencontainers.image.description="Katenary converts compose files to Helm Chart"
 LABEL org.opencontainers.image.licenses=MIT
-COPY --from=builder /go/bin/katenary /usr/local/bin/katenary
+COPY --from=builder /go/src/github.com/katenary/katenary/katenary /usr/local/bin/katenary
 VOLUME /project
 WORKDIR /project
 ENTRYPOINT ["/usr/local/bin/katenary"]


### PR DESCRIPTION
This pull request updates the OCI image build process by transitioning from Docker-based actions to Red Hat's `buildah` and `push-to-registry` GitHub Actions. The changes also include improvements to the `Containerfile` to enforce version handling and streamline the build process.

### Workflow updates for OCI image building:
* [`.github/workflows/build-oci.yaml`](diffhunk://#diff-56dbdcf547cf0e61685773f61376770ae2df223afcc33c9fcaf2f5335699cc7aL4-R6): Changed the trigger from `release` events to `push` events for all tags. Updated the workflow to use `buildah-build` and `push-to-registry` actions instead of Docker-based actions, simplifying the build and push steps. Added permissions for `packages: write` and `contents: read` to the workflow. [[1]](diffhunk://#diff-56dbdcf547cf0e61685773f61376770ae2df223afcc33c9fcaf2f5335699cc7aL4-R6) [[2]](diffhunk://#diff-56dbdcf547cf0e61685773f61376770ae2df223afcc33c9fcaf2f5335699cc7aR15-L37)

### Containerfile enhancements:
* [`oci/katenary/Containerfile`](diffhunk://#diff-dac88df79659c1a9e083208c23c8c3589ea9e1c55467cf12eedccba3b4958389L4-R23): Added a check to ensure the `VERSION` build argument is set. Replaced `go install` with `go build` to include version information in the binary using linker flags. Updated paths and build steps to align with the new build process.And set version the right way...