### PR TITLE
fix: compose convent error

### DIFF
--- a/internal/parser/main.go
+++ b/internal/parser/main.go
@@ -41,7 +41,7 @@ func Parse(profiles []string, envFiles []string, dockerComposeFile ...string) (*
 		}
 	}
 
-	options, err := cli.NewProjectOptions(nil,
+	options, err := cli.NewProjectOptions(dockerComposeFile,
 		cli.WithProfiles(profiles),
 		cli.WithInterpolation(true),
 		cli.WithDefaultConfigPath,


### PR DESCRIPTION
fix convert error about
```text
❌ Cannot parse compose files no configuration file provided: not found
```

build and test pass.